### PR TITLE
feat: Add GitHub Actions workflow and documentation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,42 @@
+name: Flutter CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build_android_web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: "11.x"
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+      - run: flutter pub get
+      - run: flutter test
+      - run: flutter build apk
+      - uses: actions/upload-artifact@v3
+        with:
+          name: release-apk
+          path: build/app/outputs/flutter-apk/app-release.apk
+      - run: flutter build web
+      - uses: actions/upload-artifact@v3
+        with:
+          name: web-build
+          path: build/web
+
+  build_ios:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+      - run: flutter pub get
+      - run: flutter build ios --no-codesign

--- a/README.md
+++ b/README.md
@@ -76,3 +76,33 @@ flutter build apk --release
 ```
 
 The generated APK file will be located in the `build/app/outputs/flutter-apk/` directory. You can then install this file on an Android device.
+
+## GitHub Actions CI Workflow
+
+This project is equipped with a GitHub Actions workflow that automates the process of building and testing the application. This ensures that every change pushed to the `main` branch is automatically verified.
+
+### Workflow Overview
+
+The CI pipeline is defined in the `.github/workflows/main.yml` file and consists of two separate jobs:
+
+1.  **Build for Android and Web**:
+    -   Runs on an `ubuntu-latest` environment.
+    -   Sets up the Flutter and Java environments.
+    -   Installs all project dependencies.
+    -   Runs the full suite of automated tests.
+    -   Builds the Android APK and the web application.
+    -   Uploads the generated APK and web build as artifacts, which can be downloaded.
+
+2.  **Build for iOS**:
+    -   Runs on a `macos-latest` environment.
+    -   Sets up the Flutter environment.
+    -   Installs dependencies.
+    -   Builds the iOS application (without code signing).
+
+### Accessing Build Artifacts
+
+After a workflow run is successfully completed on a push to the `main` branch, you can download the build artifacts (the Android APK and the web build) directly from the GitHub Actions summary page.
+
+1.  Navigate to the **Actions** tab in the GitHub repository.
+2.  Click on the most recent workflow run for the `main` branch.
+3.  On the summary page for that run, you will find an "Artifacts" section where you can download the `release-apk` and `web-build`.


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow to automate the build and test process for the Flutter application. It also updates the README.md file with a detailed explanation of the new CI workflow.

The workflow is configured with two jobs:
1.  `build_android_web` (runs on ubuntu-latest):
    - Sets up Flutter and Java.
    - Installs dependencies.
    - Runs tests.
    - Builds the Android APK and uploads it as an artifact.
    - Builds the web app and uploads it as an artifact.

2.  `build_ios` (runs on macos-latest):
    - Sets up Flutter.
    - Installs dependencies.
    - Builds the iOS app without code signing.

The README.md now includes a section explaining how the workflow operates and how to access the build artifacts.